### PR TITLE
Update pipeline to tag images with gitsha and latest

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -41,7 +41,9 @@ jobs:
           file: docker/steampipe/Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.us-west-2.amazonaws.com/steampipe:latest
+          tags: |
+            ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.us-west-2.amazonaws.com/steampipe:latest
+            ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.us-west-2.amazonaws.com/steampipe:${{ env.GIT_COMMIT_SHA }}
 
       - name: Restart the extractor-steampipe deployment
         run: kubectl rollout restart deployment extractor-steampipe -n catio-data-extraction

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -41,7 +41,9 @@ jobs:
           build-args: |
             PY_PAT=${{ secrets.PY_PAT }}
           push: true
-          tags: ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.us-west-2.amazonaws.com/steampipe:latest
+          tags: |
+            ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.us-west-2.amazonaws.com/steampipe:latest
+            ${{ env.AWS_ACCOUNT_ID }}.dkr.ecr.us-west-2.amazonaws.com/steampipe:${{ env.GIT_COMMIT_SHA }}
 
       - name: Restart the extractor-steampipe deployment
         run: kubectl rollout restart deployment extractor-steampipe -n catio-data-extraction


### PR DESCRIPTION
### What does this do?

We need the ability to pin deployments to certain versions of our steampipe image.

For instance, when we're introducing new features, or updating our forked version with updates from upstream, we want the ability to gradually roll out the new image and test it with different services. If something breaks, we want the ability to roll back to old version.

This creates two tags: one with the gitsha and one with latest. The latest tag will always move up to the latest build, while previous builds are still accessible via their gitsha. This preserves our ability rollout latest automatically when this repo pushes a new image; but also gives us the ability to rollback to a known good version when needed.